### PR TITLE
Changed log color from BLACK to WHITE

### DIFF
--- a/bioTea/__init__.py
+++ b/bioTea/__init__.py
@@ -71,7 +71,7 @@ class ColorFormatter(logging.Formatter):
         reset = Fore.RESET + Back.RESET + Style.NORMAL
         color = self.COLORS.get(record.levelname, "")
         if color:
-            record.name = Style.BRIGHT + Fore.BLACK + record.name + reset
+            record.name = Style.BRIGHT + Fore.WHITE + record.name + reset
             if record.levelname != "INFO":
                 record.msg = color + record.msg + reset
             record.levelname = color + record.levelname + reset


### PR DESCRIPTION
The current log logs the module name in black.

This was a bad choice.

![](https://media.giphy.com/media/u1edH5vUfg8xO/giphy.gif)